### PR TITLE
Update Type matching to prevent errors

### DIFF
--- a/pg_extractor.pl
+++ b/pg_extractor.pl
@@ -421,8 +421,8 @@ sub build_object_lists {
             next;
         }
         #print "restorecmd result: $_ \n";
-        my ($typetest) = /\d+;\s\d+\s\d+\s+(.*)/;
-        if ($typetest =~ /^TABLE|VIEW|TYPE|SCHEMA/) {
+        my ($typetest) = /\d+;\s\d+\s\d+\s+(\S+)/;
+        if ($typetest =~ /^(TABLE|VIEW|TYPE|SCHEMA)/) {
             # avoid output error when table data is being exported
             if ($typetest =~ /^TABLE/) {
                 if ( /\d+;\s\d+\s\d+\sTABLE\sDATA\s\S+\s\S+\s\S+/ ) {
@@ -437,7 +437,7 @@ sub build_object_lists {
                 ($objid, $objtype, $objschema, $objname, $objowner) = /(\d+;\s\d+\s\d+)\s(\S+)\s(\S+)\s(\S+)\s(\S+)/;
             }
             next RESTORE_LABEL if $objtype eq "-";
-        } elsif ($typetest =~ /^FUNCTION|AGGREGATE/) {
+        } elsif ($typetest =~ /^(FUNCTION|AGGREGATE)/) {
             ($objid, $objtype, $objschema, $objname, $objowner) = /(\d+;\s\d+\s\d+)\s(\S+)\s(\S+)\s(.*\))\s(\S+)/;
         } elsif ($typetest =~ /^COMMENT/) {
 


### PR DESCRIPTION
Change Type regex to limit to the type only (instead as the type and the... rest of the line) and correct following regexes to prevent false matches -- COMMENTS of subtype VIEW, TYPE, or SCHEMA were matching the /^TABLE|VIEW|TYPE|SCHEMA/ regex because the ^ was only applied to the TABLE option not the other options.
