### PR TITLE
Change numeric comparison to alphanumeric comparision as versions are co...

### DIFF
--- a/pg_extractor.pl
+++ b/pg_extractor.pl
@@ -900,7 +900,7 @@ sub create_role_ddl {
     my @version_elements = $version_info =~ m{(\d+)}g;
     my $version = sprintf '%03d%03d', @version_elements[0,1];
 
-    my $roles_option = $version < '008003' ? '--globals-only' : '--roles-only';
+    my $roles_option = $version lt '008003' ? '--globals-only' : '--roles-only';
 
     my $dumprolecmd = "$O->{pgdumpall} $roles_option > $filepath";
     system $dumprolecmd;


### PR DESCRIPTION
for determining roles option we are comparing $version with the string '008003'. Here $version also as a string which is formatted as "%03d%03d" in the previous step. Since we are comparing two strings, use of comparison operator lt is recommended (rather the the use of numeric comparison operator <).
