### PR TITLE
Fix for running on Windows: close temp dump file before calling pg_dump,...

### DIFF
--- a/pg_extractor.py
+++ b/pg_extractor.py
@@ -891,6 +891,7 @@ class PGExtractor:
         if self.args.debug:
             print(pg_dump_cmd)
         try:
+            self.tmp_dump_file.close()
             subprocess.check_call(pg_dump_cmd)
         except subprocess.CalledProcessError as e:
             print("Error in pg_dump command while creating template dump file: " + str(e.cmd))


### PR DESCRIPTION
... otherwise pg_dump will get a SHARING_VIOLATION accessing the dump file because more than one process has the dump file open. 
