### PR TITLE
Update python shebang to use python3 per PEP-0394

### DIFF
--- a/pg_extractor.py
+++ b/pg_extractor.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import errno


### PR DESCRIPTION
Since pg_extractor requires Python 3, it's best to use python3 rather than python in the shebang line. The Python Software Foundation recommends as follows: 

> In order to tolerate differences across platforms, all new code that needs to invoke the Python interpreter should not specify python, but rather should specify either python2 or python3 (or the more specific python2.x and python3.x versions; see the Migration Notes). **This distinction should be made in shebangs**, when invoking from a shell script, when invoking via the system() call, or when invoking in any other context.

Full text at http://legacy.python.org/dev/peps/pep-0394/