### PR TITLE
Fix database comments. Get version number back to consistency.

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,6 @@
+2.3.9
+ * Fixed handling of database comments
+
 2.3.8
 * Fix RULE extraction breaking in 9.6 due to a change in restore -l pattern (Github Issue #40).
 * Greatly simplified the code for generating pg_restore commands for individual objects (only the object id is actually required in the file given to the -L option). You may see COMMENTs showing up in files that were missing them before.


### PR DESCRIPTION
Had accidentally set the internal version value to 2.3.9 back for tagged release of 2.3.8. Just tagging this release as 2.3.9.